### PR TITLE
Fixed content overflow to remove Horizontal scrollbar

### DIFF
--- a/src/Components/Home/Home.css
+++ b/src/Components/Home/Home.css
@@ -112,13 +112,24 @@ html {
   }
 
 }
-  .content-image {
-    margin: 0;
-    padding: 0;
-    width: 105%;
-    height: 100%;
 
-  }
+.content-image {
+	margin: 0;
+	padding: 0;
+	width: 100%;
+	height: 100%;
+}
+
+.col-image{
+	width:51%;
+	object-fit: cover;
+	margin:0;
+	padding: 0;
+}
+
+.col-content{
+	width: 49%;
+}
 
 .content-area hr {
 width: 100px;

--- a/src/Components/Home/Home.js
+++ b/src/Components/Home/Home.js
@@ -17,12 +17,12 @@ class Home extends Component {
                   </div>
               </section>
 
-              <section className="content">
+              <section className="container-fluid">
                   <div className="row justify-content-center">
-                      <div className="col col">
+                      <div className="col-image">
                           <img className="content-image" src="https://i.imgur.com/azkKnMe.jpg"/>
                       </div>
-                      <div className="col col">
+                      <div className="col-content">
                         <div className="content-area">
                           <h1>subjects</h1>
                           <hr />
@@ -32,27 +32,27 @@ class Home extends Component {
                   </div>
               </section>
 
-              <section className="content">
+              <section className="container-fluid">
                   <div className="row justify-content-center">
-                      <div className="col">
+                      <div className="col-content">
                         <div className="content-area">
                           <h1>Challenge</h1>
                           <hr />
                           <h3>Choose from our largest collection of subjects.</h3>
                         </div>
                       </div>
-                      <div className="col">
+                      <div className="col-image">
                           <img className="content-image" src="https://i.imgur.com/9BWq0c7.jpg"/>
                       </div>
                   </div>
               </section>
 
-              <section className="content">
+              <section className="container-fluid">
                   <div className="row justify-content-center">
-                      <div className="col">
+                      <div className="col-image">
                           <img className="content-image" src="https://i.imgur.com/OaqZYmZ.jpg"/>
                       </div>
-                      <div className="col">
+                      <div className="col-content">
                         <div className="content-area">
                           <h1>Practice</h1>
                           <hr />


### PR DESCRIPTION
1. Fixed the content overflow by updating the image width to 100% and using built-in container-fluid classNames for sections.
2. Updated the widths of content and image parts of the sections to 49% and 51% width to get uniform layout sizes.

FIles changed: Home.js
                         Home.css

Issue ref: #61 